### PR TITLE
fix: Remove the scriptModule entry

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -33,7 +33,6 @@ await Promise.all([
       sourceMap: true,
       target: 'ES2021',
     },
-    scriptModule: false,
     shims: {
       deno: {
         test: true,


### PR DESCRIPTION
Resolves #24 

- [x] There is an associated issue (**required**)
- [x] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

To export useInk correctly, we should also emit the CommonJS output. Since it is the default [behavior](https://github.com/denoland/dnt/blob/eec75130560bcf2fe7cf562c06e91dcd423fa519/mod.ts#L63) we can entirely omit the field.
