### PR TITLE
chore: bump react as peer dependency to 18

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -20,7 +20,7 @@ await Promise.all([
     mappings: {
       'https://cdn.skypack.dev/react?dts': {
         name: 'react',
-        version: '^17.0.0',
+        version: '^18.0.0',
         peerDependency: true,
       },
     },


### PR DESCRIPTION
Resolves #

I had this issues installing useink in the `useink-kitchen-sink` testing project. I think we should directly support the most recent react version 🤷 

<img width="897" alt="Screenshot 2023-04-18 at 10 38 46" src="https://user-images.githubusercontent.com/839848/232728021-ce0bd802-8fcd-43d5-88b2-0d7b997eb42e.png">
