### PR TITLE
feat: add useink/utils

### DIFF
--- a/_tasks/dnt.ts
+++ b/_tasks/dnt.ts
@@ -18,6 +18,10 @@ await Promise.all([
         name: './notifications',
         path: 'notifications/mod.ts',
       },
+      {
+        name: './utils',
+        path: 'utils/mod.ts',
+      },
     ],
     outDir,
     importMap: 'import_map.json',

--- a/import_map.json
+++ b/import_map.json
@@ -16,7 +16,7 @@
     "@polkadot/types-codec/types": "npm:@polkadot/types-codec@9.14.2/types",
     "@polkadot/types/interfaces": "npm:@polkadot/types@9.14.2/interfaces",
     "@polkadot/types/types": "npm:@polkadot/types@9.14.2/types",
-    "@polkadot/util": "npm:@polkadot/util@10.4.1",
+    "@polkadot/util": "npm:@polkadot/util@12.2.1",
     "@talisman/connect-wallets": "npm:@talismn/connect-wallets@1.2.3",
     "bn.js": "npm:bn.js@5.2.1",
     "react": "https://cdn.skypack.dev/react?dts",

--- a/utils/mod.ts
+++ b/utils/mod.ts
@@ -1,0 +1,1 @@
+export * from '@polkadot/util';


### PR DESCRIPTION
Resolves #

- [ x] There is an associated issue (**required**)
- [ x] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

export @polkadot/utils as `useink/utils`. The goal is to allow any dApp to avoid installing any polkadotJS libraries.