### PR TITLE
feat: add pick* utility functions

### DIFF
--- a/core/mod.ts
+++ b/core/mod.ts
@@ -1,3 +1,4 @@
 export * from './hooks/mod.ts';
 export * from './providers/mod.ts';
+export * from './types/mod.ts';
 export * from './utils/mod.ts';

--- a/core/types/contracts.ts
+++ b/core/types/contracts.ts
@@ -13,6 +13,7 @@ export type {
   ContractExecResultResult,
 } from '@polkadot/types/interfaces';
 export type { AbiMessage, ContractOptions } from '@polkadot/api-contract/types';
+export type { ContractPromise } from '@polkadot/api-contract';
 export type { ContractSubmittableResult } from '@polkadot/api-contract/base/contract';
 
 export type AccountId = string;

--- a/core/types/substrate.ts
+++ b/core/types/substrate.ts
@@ -11,6 +11,7 @@ export type {
 
 export type {
   Balance,
+  DispatchError,
   EventRecord,
   ExtrinsicStatus,
   RuntimeDispatchInfo,

--- a/core/types/substrate.ts
+++ b/core/types/substrate.ts
@@ -8,6 +8,7 @@ export type {
   RegistryError,
   TypeDef,
 } from '@polkadot/types/types';
+
 export type {
   Balance,
   EventRecord,
@@ -17,6 +18,7 @@ export type {
   Weight,
   WeightV2,
 } from '@polkadot/types/interfaces';
+
 export type { SignerOptions, SubmittableExtrinsic } from '@polkadot/api/types';
 
 export type TransactionStatus =

--- a/utils/mod.ts
+++ b/utils/mod.ts
@@ -1,1 +1,6 @@
 export * from '@polkadot/util';
+
+export * from './pickDecoded.ts';
+export * from './pickError.ts';
+export * from './pickResultErr.ts';
+export * from './pickResultOk.ts';

--- a/utils/pickDecoded.ts
+++ b/utils/pickDecoded.ts
@@ -1,0 +1,9 @@
+import { DecodedContractResult } from '../mod.ts';
+
+/// pickError is a helper function to quickly get the decoded value or undefined from a
+/// contract message response
+export function pickDecoded<T>(
+  decoded: DecodedContractResult<T> | undefined,
+): T | undefined {
+  return decoded?.ok ? decoded.value.decoded : undefined;
+}

--- a/utils/pickError.ts
+++ b/utils/pickError.ts
@@ -1,0 +1,9 @@
+import { DecodedContractResult, DispatchError } from '../mod.ts';
+
+/// pickError is a helper function to quickly get a dispatch error or undefined from a
+/// contract message response
+export function pickError<T>(
+  decoded: DecodedContractResult<T> | undefined,
+): DispatchError | undefined {
+  return decoded?.ok ? undefined : decoded?.error;
+}

--- a/utils/pickResultErr.ts
+++ b/utils/pickResultErr.ts
@@ -1,0 +1,9 @@
+import { DecodedContractResult } from '../mod.ts';
+
+/// pickResultErr is a helper function to quickly get an Err result from a contract message
+/// or undefined
+export function pickResultErr<T, E>(
+  decoded: DecodedContractResult<T & { Err?: E }> | undefined,
+): E | undefined {
+  return decoded?.ok ? decoded.value.decoded?.Err : undefined;
+}

--- a/utils/pickResultOk.ts
+++ b/utils/pickResultOk.ts
@@ -1,0 +1,9 @@
+import { DecodedContractResult } from '../mod.ts';
+
+/// pickResultOk is a helper function to quickly get an Ok result from a contract message
+/// or undefined
+export function pickResultOk<T, K>(
+  decoded: DecodedContractResult<T & { Ok?: K }> | undefined,
+): K | undefined {
+  return decoded?.ok ? decoded.value.decoded?.Ok : undefined;
+}


### PR DESCRIPTION
Resolves #

- [ ] There is an associated issue (**required**)
- [x] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

* Export more types
* Add helper functions to quickly access deeply nested optional values, decoded values, and DispatchErrors

```ts
  // Use helper functions to quickly pick values from a Result<T, E>
  // Instead of doing something like this:
  // mood?.result?.ok ? mood.result.value.decoded : undefined
  const okMood = pickResultOk(mood.result);
```  