### PR TITLE
feat: add default caller option

### DIFF
--- a/core/types/substrate.ts
+++ b/core/types/substrate.ts
@@ -1,3 +1,5 @@
+export type { Bytes } from '@polkadot/types';
+
 export type {
   DeriveBalancesAccount,
   DeriveBalancesMap,

--- a/react/hooks/config/mod.ts
+++ b/react/hooks/config/mod.ts
@@ -3,3 +3,4 @@ export * from './useChainRpc.ts';
 export * from './useChainRpcList.ts';
 export * from './useChains.ts';
 export * from './useConfig.ts';
+export * from './useDefaultCaller.ts';

--- a/react/hooks/config/useDefaultCaller.ts
+++ b/react/hooks/config/useDefaultCaller.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+import { useConfig } from './useConfig.ts';
+import { ChainId } from '../../../chains/mod.ts';
+import { useChain } from './useChain.ts';
+
+export const useDefaultCaller = (chainId?: ChainId): string | undefined => {
+  const { caller } = useConfig();
+  const defaultChain = useChain();
+  if (!caller) return;
+
+  return useMemo(() => (
+    caller[`${chainId || defaultChain}` as ChainId] || caller.default
+  ), [chainId, caller, defaultChain]);
+};

--- a/react/hooks/contracts/mod.ts
+++ b/react/hooks/contracts/mod.ts
@@ -1,3 +1,4 @@
+export * from './types.ts';
 export * from './useAbiMessage.ts';
 export * from './useCall.ts';
 export * from './useCallSubscription.ts';

--- a/react/hooks/contracts/types.ts
+++ b/react/hooks/contracts/types.ts
@@ -1,0 +1,13 @@
+import { ChainId } from '../../../chains/types.ts';
+import { Abi, ContractOptions, ContractPromise } from '../../../core/mod.ts';
+
+export type CallOptions = ContractOptions & {
+  defaultCaller?: boolean;
+};
+
+export type ContractAbi = string | Record<string, unknown> | Abi;
+
+export interface ChainContract<T extends ContractPromise = ContractPromise> {
+  contract: T;
+  chainId: ChainId;
+}

--- a/react/hooks/contracts/useCallSubscription.ts
+++ b/react/hooks/contracts/useCallSubscription.ts
@@ -1,21 +1,19 @@
 import { useEffect } from 'react';
 import { useBlockHeader } from '../substrate/useBlockHeader.ts';
 import { Call, useCall } from './useCall.ts';
-import { ChainContract } from './useContract.ts';
-import { ContractOptions } from '../../../core/mod.ts';
+import { CallOptions, ChainContract } from './types.ts';
 
 export function useCallSubscription<T>(
   chainContract: ChainContract | undefined,
   message: string,
   args = [] as unknown[],
-  options?: ContractOptions,
-  caller?: string,
+  options?: CallOptions,
 ): Omit<Call<T>, 'send'> {
-  const call = useCall<T>(chainContract?.contract, message);
+  const call = useCall<T>(chainContract, message);
   const blockNumber = useBlockHeader(chainContract?.chainId)?.blockNumber;
 
   useEffect(() => {
-    call.send(args, options, caller);
+    call.send(args, options);
   }, [blockNumber]);
 
   return call;

--- a/react/hooks/contracts/useContract.ts
+++ b/react/hooks/contracts/useContract.ts
@@ -3,13 +3,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { ChainId } from '../../../chains/mod.ts';
 import { useChain } from '../config/useChain.ts';
 import { useApi } from '../substrate/useApi.ts';
-
-export type ContractAbi = string | Record<string, unknown> | Abi;
-
-export interface ChainContract<T extends ContractPromise = ContractPromise> {
-  contract: T;
-  chainId: ChainId;
-}
+import { ChainContract } from './types.ts';
 
 export function useContract<T extends ContractPromise = ContractPromise>(
   address: string,

--- a/react/hooks/contracts/useEventSubscription.ts
+++ b/react/hooks/contracts/useEventSubscription.ts
@@ -1,12 +1,12 @@
-import { Bytes } from '@polkadot/types';
 import { useContext, useEffect } from 'react';
 import { FIVE_SECONDS, HALF_A_SECOND } from '../../constants.ts';
 import { Event, EventsContext } from '../../providers/events/mod.ts';
 import { useBlockHeader } from '../substrate/useBlockHeader.ts';
 import { useConfig } from '../config/useConfig.ts';
-import { ChainContract } from './useContract.ts';
 import { useInterval } from '../internal/useInterval.ts';
 import { getExpiredItem } from '../../../utils/mod.ts';
+import { ChainContract } from './types.ts';
+import { Bytes } from '../../../core/mod.ts';
 
 export const useEventSubscription = (
   chainContract: ChainContract | undefined,

--- a/react/hooks/contracts/useEvents.ts
+++ b/react/hooks/contracts/useEvents.ts
@@ -9,18 +9,18 @@ export interface Events {
 }
 
 export const useEvents = (
-  account: AccountId | undefined,
+  contractAddress: AccountId | undefined,
   filters?: string[],
 ): Events => {
   const { events, removeEvent } = useContext(EventsContext);
 
   const contractEvents = useMemo(() => {
-    if (!account) return [];
+    if (!contractAddress) return [];
 
-    return events[account.toString()]?.filter(({ name }) =>
+    return events[contractAddress.toString()]?.filter(({ name }) =>
       filters ? filters.includes(name) : true
     ) ?? [];
-  }, [events, account]);
+  }, [events, contractAddress]);
 
   return { events: contractEvents, removeEvent };
 };

--- a/react/hooks/contracts/useTxPaymentInfo.ts
+++ b/react/hooks/contracts/useTxPaymentInfo.ts
@@ -1,15 +1,12 @@
 import { useCallback, useState } from 'react';
 import { useWallet } from '../wallets/useWallet.ts';
-import {
-  ContractOptions,
-  ContractPromise,
-  RuntimeDispatchInfo,
-  SignerOptions,
-} from '../../../core/mod.ts';
+import { RuntimeDispatchInfo, SignerOptions } from '../../../core/mod.ts';
+import { CallOptions } from './types.ts';
+import { ChainContract, useDefaultCaller } from '../mod.ts';
 
 type Send = (
-  options?: ContractOptions,
   params?: unknown[],
+  options?: CallOptions,
   signerOptions?: Partial<SignerOptions>,
 ) => Promise<RuntimeDispatchInfo | undefined>;
 
@@ -21,16 +18,21 @@ interface TxPaymentInfo {
 }
 
 export function useTxPaymentInfo(
-  contract: ContractPromise | undefined,
+  chainContract: ChainContract | undefined,
   message: string,
 ): TxPaymentInfo {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [result, setResult] = useState<RuntimeDispatchInfo>();
   const { account } = useWallet();
+  const defaultCaller = useDefaultCaller();
 
-  const send = useCallback<Send>(async (options, params, signerOptions) => {
-    const tx = contract?.tx?.[message];
-    if (!tx || !account) return;
+  const send = useCallback<Send>(async (params, options, signerOptions) => {
+    const tx = chainContract?.contract?.tx?.[message];
+    const caller = account?.address || options?.defaultCaller
+      ? defaultCaller
+      : undefined;
+
+    if (!tx || !caller) return;
 
     try {
       setIsSubmitting(true);
@@ -39,7 +41,7 @@ export function useTxPaymentInfo(
       const paymentInfoResult = await (requiresNoArguments
         ? tx(options || {})
         : tx(options || {}, params))
-        .paymentInfo(account.address, signerOptions);
+        .paymentInfo(caller, signerOptions);
 
       setResult(paymentInfoResult);
       setIsSubmitting(false);
@@ -50,7 +52,7 @@ export function useTxPaymentInfo(
       setIsSubmitting(false);
       return;
     }
-  }, [contract, message, account]);
+  }, [chainContract?.contract, message, account, defaultCaller]);
 
   return {
     isSubmitting,

--- a/react/providers/config/model.ts
+++ b/react/providers/config/model.ts
@@ -4,9 +4,14 @@ import { ArrayOneOrMore } from '../../../core/mod.ts';
 
 export type ChainRPCs = Partial<Record<ChainId, string>>;
 
+export type CallerAddress = string;
+
 export type ConfigProps = {
   dappName?: string;
   chains: ArrayOneOrMore<Chain>;
+  caller?: {
+    default?: CallerAddress;
+  } & Partial<Record<ChainId, CallerAddress>>;
   events?: {
     expiration?: number;
     checkInterval?: number;


### PR DESCRIPTION
Resolves #

- [x] There is an associated issue (**required**) (inside of the [Link dApp](https://github.com/paritytech/link)
- [x] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

Most dApps today require a user to connect their wallet before making calls to the blockchain and displaying any UI. This adds friction to users interacting with a product and is a bad user experience. (This is especially true for EVM chains). This PR introduces an optional configuration for developers to set a default caller address that can be used to make calls to contracts before the end user connects a wallet. After a user connects their wallet the connected account will be used instead of the default.

e.g. 

Configuration

```tsx
    <UseInkProvider
      config={{
        dappName: 'Dex',
        chains: [RococoContractsTestnet, RococoTestnet, ShibuyaTestnet, Astar, Phala, Aleph],
        caller: {
          default: '5CXvURDfLfjKvJunsi8cYYUULXbTYUv5YK6h9oHMJUC5ERUT',
          aleph: '5HprbfKUFdN4qfweVbgRtqDPHfNtoi8NoWPE45e5bD5AEKiR',
        }
      }
    >
      <MyRoutes />
    </UseInkProvider>
```

```tsx
const call = useCall(contract, 'foo');
const alephCall = useCall(contractOnAlephZero, 'foo');
const args = [];

// If the user's wallet is NOT connected then this will call 'foo' with the default address.
// If the user's wallet IS connected then it will use the connected address
call.send(args, { defaultCaller: true });

// If the user's wallet is NOT connected then this will call 'foo' with the Aleph Zero default address.
// If the user's wallet IS connected then it will use the connected address
alephCall.send(args, { defaultCaller: true });
```

This works with `useCall`, `useCallSubscription`, `useTxPaymentInfo`, and `useDryRun`. This feature does NOT work with `useTx`, which requires a signature.