### PR TITLE
feat: add error to useTx.signAndSend callback func

### DIFF
--- a/react/hooks/contracts/useTx.ts
+++ b/react/hooks/contracts/useTx.ts
@@ -10,8 +10,9 @@ import {
 import { ChainContract } from './types.ts';
 
 export type ContractSubmittableResultCallback = (
-  result: ContractSubmittableResult,
+  result?: ContractSubmittableResult,
   api?: ApiBase<'promise'>,
+  error?: unknown,
 ) => void;
 
 export type SignAndSend = (
@@ -50,7 +51,11 @@ export function useTx<T>(
         const tx = chainContract?.contract.tx[message];
 
         if (!tx) {
-          console.error(`'${message}' not found on contract instance`);
+          cb?.(
+            undefined,
+            chainContract.contract.api,
+            `'${message}' not found on contract instance`,
+          );
           return;
         }
 
@@ -68,12 +73,12 @@ export function useTx<T>(
             },
           )
           .catch((e: unknown) => {
-            console.error(e);
+            cb?.(undefined, chainContract.contract.api, e);
             setStatus('None');
           });
       })
         .catch((e) => {
-          console.error(e);
+          cb?.(undefined, chainContract.contract.api, e);
           setStatus('None');
         });
     },


### PR DESCRIPTION
Resolves #

- [ ] There is an associated issue (**required**)
- [ ] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

This feature need came up while implementing the lastest useink version in [tiny.ink](https://tiny.ink).

```ts
tx.signAndSend(args, options, (result, api, error) => console.error(error));
```

This gives the user opportunity to handle failures if a tx fails or if a user rejects the signature.