### PR TITLE
fix: add guard to decoding for ink v3 contracts

### DIFF
--- a/core/contracts/decodeCallResult.ts
+++ b/core/contracts/decodeCallResult.ts
@@ -20,5 +20,5 @@ export function decodeCallResult<T>(
     { isPedantic: true },
   );
 
-  return { ok: true, value: (raw.toHuman() as Record<'Ok', T>).Ok };
+  return { ok: true, value: (raw?.toHuman() as Record<'Ok', T>)?.Ok };
 }


### PR DESCRIPTION
Resolves #

- [ ] There is an associated issue (**required**)
- [ ] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

Guard against ink! v3 Option returns