### PR TITLE
fix: `txPaymentInfo` params now uses spread operator

### DIFF
--- a/packages/useink/src/core/contracts/txPaymentInfo.ts
+++ b/packages/useink/src/core/contracts/txPaymentInfo.ts
@@ -21,7 +21,7 @@ export async function txPaymentInfo(
     const requiresNoArguments = tx.meta.args.length === 0;
     return await (requiresNoArguments
       ? tx(options || {})
-      : tx(options || {}, params)
+      : tx(options || {}, ...(params || []))
     ).paymentInfo(caller, signerOptions);
   } catch (e: unknown) {
     console.error(e);


### PR DESCRIPTION
## Description
### Issue
`txPaymentInfo` would not work when a message was passed that had parameters. An error would be thrown saying "<message> requires 4 arguments but only 1 was passed".

### Solution
This PR updates `txPaymentInfo` to use the spread operator (`...params`) to destructure the `params` array to individual arguments.