### PR TITLE
fix: add correct export for core module

### DIFF
--- a/packages/useink/src/core/contracts/call.ts
+++ b/packages/useink/src/core/contracts/call.ts
@@ -4,9 +4,9 @@ import {
   AbiMessage,
   AccountId,
   ContractExecResult,
-  ContractOptions,
   ContractPromise,
   DecodedContractResult,
+  LazyContractOptions,
 } from '../types/index';
 
 import { decodeCallResult } from './decodeCallResult.ts';
@@ -16,7 +16,7 @@ export async function call<T>(
   abiMessage: AbiMessage,
   caller: AccountId | string,
   args = [] as unknown[],
-  options?: ContractOptions,
+  options?: LazyContractOptions,
 ): Promise<DecodedContractResult<T> | undefined> {
   const { value, gasLimit, storageDepositLimit } = options || {};
 

--- a/packages/useink/src/core/contracts/helpers.ts
+++ b/packages/useink/src/core/contracts/helpers.ts
@@ -1,0 +1,11 @@
+import { BN_ZERO } from '../../utils';
+import { ContractOptions, LazyContractOptions } from '../types';
+
+export const DEFAULT_CONTRACT_OPTIONS: ContractOptions = { value: BN_ZERO };
+
+export const toContractOptions = (
+  options?: LazyContractOptions,
+): ContractOptions => ({
+  ...DEFAULT_CONTRACT_OPTIONS,
+  ...(options || {}),
+});

--- a/packages/useink/src/core/contracts/index.ts
+++ b/packages/useink/src/core/contracts/index.ts
@@ -2,6 +2,7 @@ export * from './call.ts';
 export * from './decodeCallResult.ts';
 export * from './decodeError.ts';
 export * from './getRegistryError.ts';
+export * from './helpers.ts';
 export * from './toContractAbiMessage.ts';
 export * from './toRegistryErrorDecoded.ts';
 export * from './txPaymentInfo.ts';

--- a/packages/useink/src/core/contracts/txPaymentInfo.ts
+++ b/packages/useink/src/core/contracts/txPaymentInfo.ts
@@ -1,9 +1,10 @@
 import {
   AccountId,
-  ContractOptions,
   ContractPromise,
+  LazyContractOptions,
   RuntimeDispatchInfo,
   SignerOptions,
+  toContractOptions,
 } from '..';
 
 export async function txPaymentInfo(
@@ -11,7 +12,7 @@ export async function txPaymentInfo(
   message: string,
   caller: AccountId | string,
   params?: unknown[],
-  options?: ContractOptions,
+  options?: LazyContractOptions,
   signerOptions?: Partial<SignerOptions>,
 ): Promise<RuntimeDispatchInfo | undefined> {
   const tx = contract?.tx?.[message];
@@ -20,8 +21,8 @@ export async function txPaymentInfo(
   try {
     const requiresNoArguments = tx.meta.args.length === 0;
     return await (requiresNoArguments
-      ? tx(options || {})
-      : tx(options || {}, ...(params || []))
+      ? tx(toContractOptions(options))
+      : tx(toContractOptions(options), ...(params || []))
     ).paymentInfo(caller, signerOptions);
   } catch (e: unknown) {
     console.error(e);

--- a/packages/useink/src/core/index.ts
+++ b/packages/useink/src/core/index.ts
@@ -1,3 +1,3 @@
-export * from './contracts/index';
-export * from './substrate/index';
-export * from './types/index';
+export * from './contracts';
+export * from './substrate';
+export * from './types';

--- a/packages/useink/src/core/types/api-contracts.ts
+++ b/packages/useink/src/core/types/api-contracts.ts
@@ -1,0 +1,61 @@
+import { Result } from './result.ts';
+import { ISubmittableResult } from './substrate.ts';
+import { SubmittableResult } from '@polkadot/api';
+import { AbiMessage, DecodedEvent } from '@polkadot/api-contract/types';
+import {
+  Balance,
+  ContractExecResult,
+  DispatchError,
+  StorageDeposit,
+  Weight,
+} from '@polkadot/types/interfaces';
+
+export type {
+  ContractExecResult,
+  ContractExecResultResult,
+} from '@polkadot/types/interfaces';
+export type { AbiMessage, ContractOptions } from '@polkadot/api-contract/types';
+export { Abi, ContractPromise } from '@polkadot/api-contract';
+
+// rome-ignore lint/correctness/noUnusedVariables: The Release flow breaks when exporting from '@polkadot/api-contract/base/contract';
+export declare class ContractSubmittableResult extends SubmittableResult {
+  readonly contractEvents?: DecodedEvent[] | undefined;
+  constructor(result: ISubmittableResult, contractEvents?: DecodedEvent[]);
+}
+
+export interface ContractCallResultRaw {
+  readonly callResult: ContractExecResult;
+  readonly abiMessage: AbiMessage;
+}
+
+export interface CallInfo {
+  gasRequired: Weight;
+  gasConsumed: Weight;
+  storageDeposit: StorageDeposit;
+}
+
+export interface TxInfo {
+  gasRequired: Weight;
+  gasConsumed: Weight;
+  storageDeposit: StorageDeposit;
+  partialFee: Balance;
+}
+
+export interface ContractExecResultDecoded<T>
+  extends Omit<TxInfo, 'partialFee'> {
+  readonly decoded: T;
+  readonly raw: ContractExecResult;
+}
+
+export interface TxExecResultDecoded<T> extends TxInfo {
+  readonly decoded: T;
+  readonly raw: ContractExecResult;
+}
+
+export type DecodedResult<T> = Result<T, DispatchError>;
+
+export type DecodedContractResult<T> = DecodedResult<
+  ContractExecResultDecoded<T>
+>;
+
+export type DecodedTxResult<T> = DecodedResult<TxExecResultDecoded<T>>;

--- a/packages/useink/src/core/types/contracts.ts
+++ b/packages/useink/src/core/types/contracts.ts
@@ -1,61 +1,11 @@
-import { Result } from './result.ts';
-import { ISubmittableResult } from './substrate.ts';
-import { SubmittableResult } from '@polkadot/api';
-import { AbiMessage, DecodedEvent } from '@polkadot/api-contract/types';
-import {
-  Balance,
-  ContractExecResult,
-  DispatchError,
-  StorageDeposit,
-  Weight,
-} from '@polkadot/types/interfaces';
+import { Abi, ContractOptions } from './api-contracts';
 
-export type {
-  ContractExecResult,
-  ContractExecResultResult,
-} from '@polkadot/types/interfaces';
-export type { AbiMessage, ContractOptions } from '@polkadot/api-contract/types';
-export { Abi, ContractPromise } from '@polkadot/api-contract';
+export type ContractAbi = string | Record<string, unknown> | Abi;
 
-// rome-ignore lint/correctness/noUnusedVariables: The Release flow breaks when exporting from '@polkadot/api-contract/base/contract';
-export declare class ContractSubmittableResult extends SubmittableResult {
-  readonly contractEvents?: DecodedEvent[] | undefined;
-  constructor(result: ISubmittableResult, contractEvents?: DecodedEvent[]);
-}
+// Lazy contract options allow for developers to rely on default values that will be
+// lazily added so that they don't have to pass in `{ value: BN }` every time.
+export type LazyContractOptions = Partial<ContractOptions>;
 
-export interface ContractCallResultRaw {
-  readonly callResult: ContractExecResult;
-  readonly abiMessage: AbiMessage;
-}
-
-export interface CallInfo {
-  gasRequired: Weight;
-  gasConsumed: Weight;
-  storageDeposit: StorageDeposit;
-}
-
-export interface TxInfo {
-  gasRequired: Weight;
-  gasConsumed: Weight;
-  storageDeposit: StorageDeposit;
-  partialFee: Balance;
-}
-
-export interface ContractExecResultDecoded<T>
-  extends Omit<TxInfo, 'partialFee'> {
-  readonly decoded: T;
-  readonly raw: ContractExecResult;
-}
-
-export interface TxExecResultDecoded<T> extends TxInfo {
-  readonly decoded: T;
-  readonly raw: ContractExecResult;
-}
-
-export type DecodedResult<T> = Result<T, DispatchError>;
-
-export type DecodedContractResult<T> = DecodedResult<
-  ContractExecResultDecoded<T>
->;
-
-export type DecodedTxResult<T> = DecodedResult<TxExecResultDecoded<T>>;
+export type LazyCallOptions = LazyContractOptions & {
+  defaultCaller?: boolean;
+};

--- a/packages/useink/src/core/types/index.ts
+++ b/packages/useink/src/core/types/index.ts
@@ -1,4 +1,5 @@
 export * from './array.ts';
+export * from './api-contracts.ts';
 export * from './contracts.ts';
 export * from './result.ts';
 export * from './substrate.ts';

--- a/packages/useink/src/react/hooks/contracts/types.ts
+++ b/packages/useink/src/react/hooks/contracts/types.ts
@@ -1,11 +1,5 @@
 import { ChainId } from '../../../chains/types.ts';
-import { Abi, ContractOptions, ContractPromise } from '../../../core/index';
-
-export type CallOptions = ContractOptions & {
-  defaultCaller?: boolean;
-};
-
-export type ContractAbi = string | Record<string, unknown> | Abi;
+import { ContractPromise } from '../../../core/index';
 
 export interface ChainContract<T extends ContractPromise = ContractPromise> {
   contract: T;

--- a/packages/useink/src/react/hooks/contracts/useCall.ts
+++ b/packages/useink/src/react/hooks/contracts/useCall.ts
@@ -1,13 +1,16 @@
-import { DecodedContractResult, call } from '../../../core/index';
+import {
+  DecodedContractResult,
+  LazyCallOptions,
+  call,
+} from '../../../core/index';
 import { ChainContract, useDefaultCaller } from '../index';
 import { useWallet } from '../wallets/useWallet.ts';
-import { CallOptions } from './types.ts';
 import { useAbiMessage } from './useAbiMessage.ts';
 import { useCallback, useState } from 'react';
 
 export type CallSend<T> = (
   args?: unknown[],
-  options?: CallOptions,
+  options?: LazyCallOptions,
 ) => Promise<DecodedContractResult<T> | undefined>;
 
 export interface UseCall<T> {

--- a/packages/useink/src/react/hooks/contracts/useCallSubscription.ts
+++ b/packages/useink/src/react/hooks/contracts/useCallSubscription.ts
@@ -1,5 +1,6 @@
+import { LazyCallOptions } from '../../../core/index.ts';
 import { useBlockHeader } from '../substrate/useBlockHeader.ts';
-import { CallOptions, ChainContract } from './types.ts';
+import { ChainContract } from './types.ts';
 import { Call, useCall } from './useCall.ts';
 import { useEffect } from 'react';
 
@@ -7,7 +8,7 @@ export function useCallSubscription<T>(
   chainContract: ChainContract | undefined,
   message: string,
   args = [] as unknown[],
-  options?: CallOptions,
+  options?: LazyCallOptions,
 ): Omit<Call<T>, 'send'> {
   const call = useCall<T>(chainContract, message);
   const blockNumber = useBlockHeader(chainContract?.chainId)?.blockNumber;

--- a/packages/useink/src/react/hooks/contracts/useDryRun.ts
+++ b/packages/useink/src/react/hooks/contracts/useDryRun.ts
@@ -1,7 +1,12 @@
-import { DecodedTxResult, call } from '../../../core/index';
+import {
+  DecodedTxResult,
+  LazyCallOptions,
+  call,
+  toContractOptions,
+} from '../../../core/index';
 import { useDefaultCaller } from '../config/index';
 import { useWallet } from '../wallets/useWallet.ts';
-import { CallOptions, ChainContract } from './types.ts';
+import { ChainContract } from './types.ts';
 import { useAbiMessage } from './useAbiMessage.ts';
 import { useMemo, useState } from 'react';
 
@@ -9,7 +14,7 @@ export type DryRunResult<T> = DecodedTxResult<T>;
 
 export type Send<T> = (
   args?: unknown[],
-  o?: CallOptions,
+  o?: LazyCallOptions,
   caller?: string,
 ) => Promise<DryRunResult<T> | undefined>;
 
@@ -61,8 +66,8 @@ export function useDryRun<T>(
 
         const requiresNoArguments = tx.meta.args.length === 0;
         const { partialFee } = await (requiresNoArguments
-          ? tx(options || {})
-          : tx(options || {}, ...(params || []))
+          ? tx(toContractOptions(options))
+          : tx(toContractOptions(options), ...(params || []))
         ).paymentInfo(caller);
 
         const r = {

--- a/packages/useink/src/react/hooks/contracts/useTx.ts
+++ b/packages/useink/src/react/hooks/contracts/useTx.ts
@@ -1,8 +1,9 @@
 import {
   ApiBase,
-  ContractOptions,
   ContractSubmittableResult,
+  LazyContractOptions,
   TransactionStatus,
+  toContractOptions,
 } from '../../../core/index';
 import { useWallet } from '../wallets/useWallet.ts';
 import { ChainContract } from './types.ts';
@@ -17,7 +18,7 @@ export type ContractSubmittableResultCallback = (
 
 export type SignAndSend = (
   args?: unknown[],
-  o?: ContractOptions,
+  o?: LazyContractOptions,
   cb?: ContractSubmittableResultCallback,
 ) => void;
 
@@ -61,7 +62,10 @@ export function useTx<T>(
             return;
           }
 
-          tx({ gasLimit: gasRequired, ...(options || {}) }, ...(params || []))
+          tx(
+            { gasLimit: gasRequired, ...toContractOptions(options) },
+            ...(params || []),
+          )
             .signAndSend(
               account.address,
               { signer: account.wallet?.extension?.signer },

--- a/packages/useink/src/react/hooks/contracts/useTxPaymentInfo.ts
+++ b/packages/useink/src/react/hooks/contracts/useTxPaymentInfo.ts
@@ -1,16 +1,16 @@
 import { ChainContract, useDefaultCaller } from '..';
 import {
+  LazyCallOptions,
   RuntimeDispatchInfo,
   SignerOptions,
   txPaymentInfo,
 } from '../../../core';
 import { useWallet } from '../wallets/useWallet.ts';
-import { CallOptions } from './types.ts';
 import { useCallback, useState } from 'react';
 
 type Send = (
   params?: unknown[],
-  options?: CallOptions,
+  options?: LazyCallOptions,
   signerOptions?: Partial<SignerOptions>,
 ) => Promise<RuntimeDispatchInfo | undefined>;
 

--- a/packages/useink/tsup.config.ts
+++ b/packages/useink/tsup.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   format: ['cjs', 'esm'],
   entry: {
     index: 'src/index.ts',
-    core: 'src/index.ts',
+    core: 'src/core/index.ts',
     chains: 'src/chains/index.ts',
     notifications: 'src/notifications/index.ts',
     utils: 'src/utils/index.ts',


### PR DESCRIPTION
Resolves #

- [ ] There is an associated issue (**required**)
- [ ] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

The core lib had a bad export. This fixes the core lib export, and has has type updates for polkadot api's new required `{ value: BN }` contract options.