### PR TITLE
fix: remove crypto dependency for browser compatibility

### DIFF
--- a/packages/useink/package.json
+++ b/packages/useink/package.json
@@ -12,7 +12,7 @@
     "React",
     "hooks"
   ],
-  "version": "1.9.1",
+  "version": "1.9.2",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "description": "A React hooks library for ink! contracts",
@@ -88,5 +88,8 @@
         "default": "./dist/utils.js"
       }
     }
+  },
+  "dependencies": {
+    "nanoid": "3"
   }
 }

--- a/packages/useink/src/utils/helpers/pseudoRandomId.ts
+++ b/packages/useink/src/utils/helpers/pseudoRandomId.ts
@@ -1,15 +1,3 @@
-export const pseudoRandomId = (t = 21) =>
-  crypto.getRandomValues(new Uint8Array(t)).reduce(
-    (t, e) =>
-      // rome-ignore lint: fancy code
-      (t +=
-        // rome-ignore lint: fancy code
-        (e &= 63) < 36
-          ? e.toString(36)
-          : e < 62
-          ? (e - 26).toString(36).toUpperCase()
-          : e > 62
-          ? '-'
-          : '_'),
-    '',
-  );
+import { nanoid } from 'nanoid';
+
+export const pseudoRandomId = (t = 21) => nanoid(t);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
 
   packages/useink:
     dependencies:
+      nanoid:
+        specifier: '3'
+        version: 3.3.6
       react:
         specifier: ^18.0.0
         version: 18.2.0


### PR DESCRIPTION
Resolves #

- [x] There is an associated issue (**required**) 
- [ ] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

Fix for [this issue](https://github.com/paritytech/useink/issues/94)

`crypto` is not browser friendly after webpack made recent changes.