### PR TITLE
fix: useCall now uses connected wallet or default caller

### DIFF
--- a/packages/useink/src/react/hooks/contracts/useCall.ts
+++ b/packages/useink/src/react/hooks/contracts/useCall.ts
@@ -41,9 +41,13 @@ export function useCall<T>(
   const send = useCallback(
     async (
       args: Parameters<typeof call>[3],
-      options: Parameters<typeof call>[4],
+      options?: LazyCallOptions,
     ): Promise<DecodedContractResult<T> | undefined> => {
-      const caller = account?.address ? defaultCaller : undefined;
+      const caller = account?.address
+        ? account.address
+        : options?.defaultCaller
+        ? defaultCaller
+        : undefined;
       if (!abiMessage || !chainContract?.contract || !caller) return;
 
       try {

--- a/packages/useink/src/react/hooks/contracts/useDryRun.ts
+++ b/packages/useink/src/react/hooks/contracts/useDryRun.ts
@@ -15,7 +15,6 @@ export type DryRunResult<T> = DecodedTxResult<T>;
 export type Send<T> = (
   args?: unknown[],
   o?: LazyCallOptions,
-  caller?: string,
 ) => Promise<DryRunResult<T> | undefined>;
 
 export interface DryRun<T> {


### PR DESCRIPTION
Resolves #

- [ ] There is an associated issue (**required**)
- [ ] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

`useCall` had a bug where the connected wallet address was not used as the caller. This PR fixes it.