### PR TITLE
fix: deploy contracts with multiple args

### DIFF
--- a/packages/useink/package.json
+++ b/packages/useink/package.json
@@ -12,7 +12,7 @@
     "React",
     "hooks"
   ],
-  "version": "1.12.0",
+  "version": "1.13.0",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "description": "A React hooks library for ink! contracts",

--- a/packages/useink/src/react/hooks/contracts/useDeployer/useDeployer.ts
+++ b/packages/useink/src/react/hooks/contracts/useDeployer/useDeployer.ts
@@ -112,8 +112,10 @@ export function useDeployer<T>(chainId?: ChainId): Deploy<T> {
           return;
         }
 
-        const messageParams = constructorMessage.toU8a(
-          toMessageParams(chainApi.api, abiParams, constructorParams || {}),
+        const messageParams = toMessageParams(
+          chainApi.api,
+          abiParams,
+          constructorParams || {},
         );
 
         const caller =
@@ -134,7 +136,7 @@ export function useDeployer<T>(chainId?: ChainId): Deploy<T> {
           gasLimitMax,
           storageDepositMax,
           codeHash ? { Existing: codeHash } : { Upload: abi.info.source.wasm },
-          messageParams,
+          constructorMessage.toU8a(messageParams),
           options?.salt ? encodeSalt(options?.salt) : '',
         ];
 
@@ -173,9 +175,10 @@ export function useDeployer<T>(chainId?: ChainId): Deploy<T> {
             storageDepositLimit: res.storageDeposit.asCharge || null,
             ...toDeployOptions(options),
           };
+
           tx =
             constructorMessage.args.length > 0
-              ? method?.(methodOptions, messageParams)
+              ? method?.(methodOptions, ...messageParams)
               : method?.(methodOptions);
         } catch (e: unknown) {
           setError(e?.toString());


### PR DESCRIPTION
Resolves #

- [ ] There is an associated issue (**required**)
- [ ] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

Deploying contracts with more than one constructor arg used to fail. This fixes it.