### PR TITLE
fix: `setResult` on `undefined` or `DispatchError`

### DIFF
--- a/packages/useink/src/core/types/talisman-connect-wallets.ts
+++ b/packages/useink/src/core/types/talisman-connect-wallets.ts
@@ -1,6 +1,6 @@
 export { getWalletBySource, getWallets } from '@talismn/connect-wallets';
-import type { Wallet } from '@talismn/connect-wallets';
 import { Signer } from './api';
+import type { Wallet } from '@talismn/connect-wallets';
 
 export interface WalletAccount {
   // Talisman sets the type as unknown so we must manually set it to Signer

--- a/packages/useink/src/react/hooks/contracts/useCall.ts
+++ b/packages/useink/src/react/hooks/contracts/useCall.ts
@@ -1,4 +1,3 @@
-import { useCallback, useState } from 'react';
 import {
   DecodedContractResult,
   LazyCallOptions,
@@ -7,6 +6,7 @@ import {
 import { ChainContract, useDefaultCaller } from '../index';
 import { useWallet } from '../wallets/useWallet.ts';
 import { useAbiMessage } from './useAbiMessage.ts';
+import { useCallback, useState } from 'react';
 
 export type CallSend = (
   args?: Array<unknown>,

--- a/packages/useink/src/react/hooks/contracts/useDryRun.ts
+++ b/packages/useink/src/react/hooks/contracts/useDryRun.ts
@@ -1,4 +1,3 @@
-import { useCallback, useState } from 'react';
 import {
   DecodedTxResult,
   LazyCallOptions,
@@ -9,6 +8,7 @@ import { useDefaultCaller } from '../config/index';
 import { useWallet } from '../wallets/useWallet.ts';
 import { ChainContract } from './types.ts';
 import { useAbiMessage } from './useAbiMessage.ts';
+import { useCallback, useState } from 'react';
 
 type DryRunResult<T> = DecodedTxResult<T> | undefined;
 

--- a/packages/useink/src/react/hooks/contracts/useTx.ts
+++ b/packages/useink/src/react/hooks/contracts/useTx.ts
@@ -10,7 +10,7 @@ import { useWallet } from '../wallets/useWallet.ts';
 import { ChainContract } from './types.ts';
 import { useDryRun } from './useDryRun.ts';
 import { useTxEvents } from './useTxEvents.ts';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 export type ContractSubmittableResultCallback = (
   result?: ContractSubmittableResult,


### PR DESCRIPTION
Resolves #96

https://github.com/paritytech/useink/blob/e808173f12adbb29fed9bdbf509f2578fdd97d12/packages/useink/src/react/hooks/contracts/useDryRun.ts#L61-L64


- [X] There is an associated issue (**required**)
- [ ] The change is described in detail
- [ ] There are new or updated tests validating the change (if applicable)

## Description

Also syncs `useCall` and `useDryRun` code and aligning some type names. 