### PR TITLE
chore: Update Phala testnet endpoint URL

### DIFF
--- a/packages/useink/src/chains/data/testnet-chaindata.ts
+++ b/packages/useink/src/chains/data/testnet-chaindata.ts
@@ -543,7 +543,7 @@ export const PhalaTestnet: IChain<'phala-testnet'> = {
   id: 'phala-testnet',
   name: 'Phala Testnet',
   account: '*25519',
-  rpcs: ['wss://poc5.phala.network/ws'],
+  rpcs: ['wss://poc6.phala.network/ws'],
 } as const;
 
 export const PhoenixTestnet: IChain<'phoenix-testnet'> = {


### PR DESCRIPTION
The PoC5 testnet is deprecated and took down soon, so this PR propose for update the endpoint URL to the testnet